### PR TITLE
Patches for “Gru” Model of ChromeBook (Non-DepthCharge) LibreBoot U-Boot

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -19,11 +19,15 @@ source=(
   https://cdn.kernel.org/pub/linux/kernel/v${pkgver%%.*}.x/${_srcname}.tar.xz
   0001-net-smsc95xx-Allow-mac-address-to-be-set-as-a-parame.patch
   0002-arm64-dts-rockchip-disable-pwm0-on-rk3399-firefly.patch
+  cadmium-gru.0001-drm-bridge-analogix_dp-Don-t-return-EBUSY-when-msg-s.patch
+  cadmium-gru.0002-drm-rockchip-Only-wait-for-panel-ACK-on-PSR-entry.patch
   config
 )
 sha256sums=('b9fd616facd6becfceef88b9be718d0f16625cab3fe81d11384802a7091e85ec'
             '013ab7f5bcf2cd486e819fb13fde1f673ac72978984a8befea13938eaf8ddd8e'
             'bcb8a42654df5f9670367950daaa01b165c15618f827d18b7b2a8d53d39227a4'
+            'a83304fdf07d3497147f07131595f3aea09e1f8d2c54cd48bed174f68a1221dc'
+            '915aefb009189993de12ebdf6a01f0e533fbcee4c6fd0f78115fcbdc110bc7e9'
             '9374d84c8d45d29c37ca4ebe295deb5302f413a53b3d5dc6b7778fce913e9bc7')
 
 prepare() {

--- a/cadmium-gru.0001-drm-bridge-analogix_dp-Don-t-return-EBUSY-when-msg-s.patch
+++ b/cadmium-gru.0001-drm-bridge-analogix_dp-Don-t-return-EBUSY-when-msg-s.patch
@@ -1,0 +1,44 @@
+From 6958888b47956821a2bbbaeeb2deb27d32337bf0 Mon Sep 17 00:00:00 2001
+From: SolidHal <hal@halemmerich.com>
+Date: Wed, 23 Dec 2020 09:24:11 -0800
+Subject: [PATCH 1/2] drm/bridge: analogix_dp: Don't return -EBUSY when
+ msg->size is 0 in aux transaction
+
+The analogix_dp_transfer() will return -EBUSY if num_transferred is zero.
+But sometimes we will send a bare address packet to start the transaction,
+like drm_dp_i2c_xfer() show:
+	......
+	/* Send a bare address packet to start the transaction.
+	 * Zero sized messages specify an address only (bare
+	 * address) transaction.
+	 */
+	msg.buffer = NULL;
+	msg.size = 0;
+	err = drm_dp_i2c_do_msg(aux, &msg);
+	......
+
+In this case, the msg->size is zero, so the num_transferred will be zero too.
+We can't return -EBUSY here, let's we return num_transferred if num_transferred
+equals msg->size.
+
+from: https://chromium.googlesource.com/chromiumos/third_party/kernel/+/e7629f9b475ce9a0b70126e907049b0e1468010d%5E%21/#F0
+---
+ drivers/gpu/drm/bridge/analogix/analogix_dp_reg.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/bridge/analogix/analogix_dp_reg.c b/drivers/gpu/drm/bridge/analogix/analogix_dp_reg.c
+index 914c569ab8c1..ee6cda10bca4 100644
+--- a/drivers/gpu/drm/bridge/analogix/analogix_dp_reg.c
++++ b/drivers/gpu/drm/bridge/analogix/analogix_dp_reg.c
+@@ -1222,7 +1222,7 @@ ssize_t analogix_dp_transfer(struct analogix_dp_device *dp,
+ 		 (msg->request & ~DP_AUX_I2C_MOT) == DP_AUX_NATIVE_READ)
+ 		msg->reply = DP_AUX_NATIVE_REPLY_ACK;
+ 
+-	return num_transferred > 0 ? num_transferred : -EBUSY;
++	return (num_transferred == msg->size) ? num_transferred : -EBUSY;
+ 
+ aux_error:
+ 	/* if aux err happen, reset aux */
+-- 
+2.20.1
+

--- a/cadmium-gru.0002-drm-rockchip-Only-wait-for-panel-ACK-on-PSR-entry.patch
+++ b/cadmium-gru.0002-drm-rockchip-Only-wait-for-panel-ACK-on-PSR-entry.patch
@@ -1,0 +1,41 @@
+From 30dcb9e2d1af10290d0764860b47b6f4848a1b93 Mon Sep 17 00:00:00 2001
+From: SolidHal <hal@halemmerich.com>
+Date: Wed, 23 Dec 2020 10:03:26 -0800
+Subject: [PATCH 1/1] bridge/analogix: Don't wait for panel ACK on PSR exit
+
+We currently wait for the panel to mirror our intended PSR state
+before continuing on both PSR enter and PSR exit. This is really
+only important to do when we're entering PSR, since we want to
+be sure the last frame we pushed is being served from the panel's
+internal fb before shutting down the soc blocks (vop/analogix).
+
+This patch changes the behavior such that we only wait for the
+panel to complete the PSR transition when we're entering PSR, and
+to skip verification when we're exiting.
+
+Without this, the system essentially freezes for ~100ms while it
+waits for confirmation that PSR is disabled. The most noticible
+behavior is the cursor jumping on quick inputs. 
+
+from: https://chromium.googlesource.com/chromiumos/third_party/kernel/+/e47a7da072d1a2ca8fdc62f3e32291c0d1a41145%5E%21/#F0
+Signed-off-by: Hal Emmerich <hal@halemmerich.com>
+---
+ drivers/gpu/drm/bridge/analogix/analogix_dp_core.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/gpu/drm/bridge/analogix/analogix_dp_core.c b/drivers/gpu/drm/bridge/analogix/analogix_dp_core.c
+index aa1bb86293fd..163bc069f77a 100644
+--- a/drivers/gpu/drm/bridge/analogix/analogix_dp_core.c
++++ b/drivers/gpu/drm/bridge/analogix/analogix_dp_core.c
+@@ -1055,7 +1055,7 @@ static int analogix_dp_disable_psr(struct analogix_dp_device *dp)
+ 	psr_vsc.db[0] = 0;
+ 	psr_vsc.db[1] = 0;
+ 
+-	return analogix_dp_send_psr_spd(dp, &psr_vsc, true);
++	return analogix_dp_send_psr_spd(dp, &psr_vsc, false);
+ }
+ 
+ /*
+-- 
+2.20.1
+


### PR DESCRIPTION
Hi, 

I would like to briefly clarify what why this pull request exists is as I’m aware your repo isn’t aiming to support ChromeBooks (at least, I’m interpreting this as supporting it the ALARM way, which of course means accommodating for Google’s DepthCharge boot payload rather).  This isn’t about DepthCharge however.

I’m not requesting for Google DepthCharge support.  Not all ARM64 ChromeBooks are limited to DepthCharge to boot Linux as LibreBoot support does exist for two RK3399 ARM64 ChromeBooks at the moment, one of which is known as “Gru”—LibreBoot-supported ARM64 ChromeBooks to my understanding and knowledge are able to boot unpatched 6.1 LTS kernels, though support is enhanced improved with patches.  My C101 “Gru” ChromeBook unit has LibreBoot with the more traditional U-Boot payload (which is able to boot completely unmodified regular generic ARM64 Ubuntu, Debian, and Fedora images without issue from my testing).

I was wondering if you would be willing to incorporate these device-specific patches to better support this hardware, the only things that are needed to support it as shown by my fork is by simply adding two patch files and their sha256 hashes.  I perfectly understand if you prefer not to add these patches though however.

Thanks and have a great day!